### PR TITLE
Rename train mode to record mode.

### DIFF
--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -4,9 +4,9 @@
         "description": "Title of the app displayed in AppBar & Navigation Drawer"
     },
 
-    "trainModeTitle": "Train",
-    "@trainModeTitle": {
-        "description": "Title for bottom navigation Train mode item"
+    "recordModeTitle": "Record",
+    "@recordModeTitle": {
+        "description": "Title for bottom navigation Record mode item"
     },
 
     "transcribeModeTitle": "Transcribe",

--- a/lib/l10n/app_it.arb
+++ b/lib/l10n/app_it.arb
@@ -1,6 +1,6 @@
 {
     "appTitle": "Project Euphonia",
-    "trainModeTitle": "Addestramento",
+    "recordModeTitle": "Registrare",
     "transcribeModeTitle": "Trascrivi",
     "recordButtonTitle": "Registra",
     "reRecordButtonTitle": "Registra nuovamente",

--- a/lib/src/auth_gate.dart
+++ b/lib/src/auth_gate.dart
@@ -13,23 +13,32 @@ class AuthGate extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<User?>(
-      stream: FirebaseAuth.instance.authStateChanges(),
-      builder: (context, snapshot) {
-        if (!snapshot.hasData) {
-          return SignInScreen(
-            providers: [
-              EmailAuthProvider(),
-              GoogleProvider(
-                  clientId: Platform.isAndroid
-                      ? (DefaultFirebaseOptions.ios.androidClientId ?? "")
-                      : (DefaultFirebaseOptions.ios.iosClientId ?? "")),
-            ],
-          );
-        }
-
-        return const HomeController();
-      },
-    );
+    return AuthStateListener<AuthController>(
+        listener: (oldState, state, controller) {
+          if (state is AuthFailed) {
+            ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+              content: ErrorText(exception: state.exception),
+            ));
+          }
+          return null;
+        },
+        child: StreamBuilder<User?>(
+          stream: FirebaseAuth.instance.authStateChanges(),
+          builder: (context, snapshot) {
+            if (!snapshot.hasData) {
+              return SignInScreen(
+                providers: [
+                  EmailAuthProvider(),
+                  GoogleProvider(
+                      clientId: Platform.isAndroid
+                          ? (DefaultFirebaseOptions.ios.androidClientId ?? "")
+                          : (DefaultFirebaseOptions.ios.iosClientId ?? "")),
+                ],
+                showPasswordVisibilityToggle: true,
+              );
+            }
+            return const HomeController();
+          },
+        ));
   }
 }

--- a/lib/src/home.dart
+++ b/lib/src/home.dart
@@ -19,7 +19,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'generated/l10n/app_localizations.dart';
-import 'modes/train_mode_controller.dart';
+import 'modes/record_mode_controller.dart';
 import 'modes/transcribe_mode_controller.dart';
 import 'repos/phrases_repository.dart';
 import 'repos/settings_repository.dart';
@@ -66,7 +66,7 @@ class _HomeControllerState extends State<HomeController> {
   @override
   Widget build(BuildContext context) {
     final List<Widget> widgetOptions = <Widget>[
-      const TrainModeController(),
+      const RecordModeController(),
       const TranscribeModeController(),
       const Center(
         child: IconButton(
@@ -182,7 +182,7 @@ class _HomeControllerState extends State<HomeController> {
         items: <BottomNavigationBarItem>[
           BottomNavigationBarItem(
               icon: const Icon(Icons.mic),
-              label: AppLocalizations.of(context)!.trainModeTitle),
+              label: AppLocalizations.of(context)!.recordModeTitle),
           BottomNavigationBarItem(
             icon: const Icon(Icons.hearing),
             label: AppLocalizations.of(context)!.transcribeModeTitle,

--- a/lib/src/modes/record_mode_controller.dart
+++ b/lib/src/modes/record_mode_controller.dart
@@ -21,17 +21,17 @@ import '../repos/phrase.dart';
 import '../repos/phrases_repository.dart';
 import '../repos/settings_repository.dart';
 import '../repos/uploader.dart';
-import 'train_mode_view.dart';
+import 'record_mode_view.dart';
 import 'upload_status.dart';
 
-class TrainModeController extends StatefulWidget {
-  const TrainModeController({super.key});
+class RecordModeController extends StatefulWidget {
+  const RecordModeController({super.key});
 
   @override
-  State<TrainModeController> createState() => _TrainModeControllerState();
+  State<RecordModeController> createState() => _RecordModeControllerState();
 }
 
-class _TrainModeControllerState extends State<TrainModeController> {
+class _RecordModeControllerState extends State<RecordModeController> {
   var _uploadStatus = UploadStatus.notStarted;
   final Key _key = GlobalKey();
   final _pageController = PageController(initialPage: 0, viewportFraction: 0.8);
@@ -151,7 +151,7 @@ class _TrainModeControllerState extends State<TrainModeController> {
                 autoAdvance: false)
             .then((_) => _showRecordingTooLongDialog());
       }
-      return TrainModeView(
+      return RecordModeView(
         type: repo.currentPhraseType,
         phrasesByType: repo.phrasesByType,
         index: repo.currentPhraseIndex,

--- a/lib/src/modes/record_mode_view.dart
+++ b/lib/src/modes/record_mode_view.dart
@@ -22,7 +22,7 @@ import '../repos/phrases_repository.dart';
 import 'phrase_view.dart';
 import 'upload_status.dart';
 
-class TrainModeView extends StatelessWidget {
+class RecordModeView extends StatelessWidget {
   final PhraseType type;
   final Map<PhraseType, List> phrasesByType;
   final int index;
@@ -40,7 +40,7 @@ class TrainModeView extends StatelessWidget {
   final UploadStatus uploadStatus;
   final PageController? controller;
 
-  const TrainModeView(
+  const RecordModeView(
       {super.key,
       required this.pageStorageKey,
       required this.type,

--- a/lib/src/settings/settings_view.dart
+++ b/lib/src/settings/settings_view.dart
@@ -34,7 +34,7 @@ class SettingsView extends StatelessWidget {
     final children = [
       const SizedBox(height: 36),
       ListTile(
-          title: Text(AppLocalizations.of(context)!.trainModeTitle,
+          title: Text(AppLocalizations.of(context)!.recordModeTitle,
               style: Theme.of(context)
                   .textTheme
                   .labelLarge


### PR DESCRIPTION
We don't want to confuse the user between whether train refers to the task of training their personalized speech model or the task of recording phrases for training. Renaming the mode to "record" clears up this confusion.